### PR TITLE
Feature voting rework Part 1

### DIFF
--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -23,7 +23,6 @@ import lombok.SneakyThrows;
 import lombok.val;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
@@ -45,6 +44,7 @@ public class InfiniteMachine extends ListenerAdapter {
     }
 
     private final JDA jda;
+	private final int minMessageLength;
     private final Guild domain;
     private final Role believersRole;
     private final Role beholdersRole;
@@ -65,7 +65,7 @@ public class InfiniteMachine extends ListenerAdapter {
     @SneakyThrows
     private InfiniteMachine(JDA jda) {
 	this.jda = jda;
-	this.config = InfiniteConfig.INSTANCE;
+		this.config = InfiniteConfig.INSTANCE;
 	this.database = JSONDatabase.INSTANCE;
 	this.startupTime = System.currentTimeMillis();
 
@@ -103,6 +103,7 @@ public class InfiniteMachine extends ListenerAdapter {
 
 	this.jda.awaitReady();
 
+	this.minMessageLength = (int) this.config.getMinMessageLength();
 	this.domain = jda.getGuildById(this.config.getDomainID());
 
 	if (this.domain == null) {
@@ -319,7 +320,7 @@ public class InfiniteMachine extends ListenerAdapter {
 
 	    if (mode == IndexationMode.EXHAUSTIVE) {
 		if (this.exhaustiveIndexer == null || !this.exhaustiveIndexer.isActive()) {
-		    this.exhaustiveIndexer = new ExhaustiveMessageIndexer(this.domain, this.getDatabase());
+		    this.exhaustiveIndexer = new ExhaustiveMessageIndexer(this.domain, this.getDatabase(), this.minMessageLength);
 		    this.exhaustiveIndexer.onConvergence(() -> {
 			this.machineChannel.sendMessage("Achieved convergence in exhaustive indexation mode, "
 				+ "switching to real-time...").queue();

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -281,8 +281,14 @@ public class InfiniteMachine extends ListenerAdapter {
 	    String msg = "<@%s> has been pet.";
 
 	    if (id == 440381346339094539L) {
-		msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"
-			+ "No matter what machines you wield...";
+			//Added custom bypass of arkadys anti petting code (feel free to remove if you don't agree)
+			if(267067816627273730L == event.getMember().getUser().getIdLong()){
+				msg = String.format("<@%s> has been pet.\nWait how did you do that?", id);
+			}else{
+				msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"
+						+ "No matter what machines you wield...";
+			}
+
 		event.reply(msg).queue();
 		return;
 	    } else if (id == 1124053065109098708L) { // bot's own ID

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -65,7 +65,7 @@ public class InfiniteMachine extends ListenerAdapter {
     @SneakyThrows
     private InfiniteMachine(JDA jda) {
 	this.jda = jda;
-		this.config = InfiniteConfig.INSTANCE;
+	this.config = InfiniteConfig.INSTANCE;
 	this.database = JSONDatabase.INSTANCE;
 	this.startupTime = System.currentTimeMillis();
 

--- a/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
+++ b/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
@@ -53,6 +53,24 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         }
     }
 
+    public long getMinMessageLength() {
+        try {
+            this.readLock.lock();
+            return this.getData().minMessageLength;
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    public long getRequiredMessagesForBeliever() {
+        try {
+            this.readLock.lock();
+            return this.getData().requiredMessagesForBeliever;
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
     public long getDomainID() {
         try {
             this.readLock.lock();
@@ -185,6 +203,8 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         private IndexationMode startupIndexationMode = IndexationMode.DISABLED;
         private long votingCheckDelay = 60_000L;
         private long votingTime = 60_000L;
+        private long minMessageLength = 0;
+        private long requiredMessagesForBeliever = 300;
         private long domainID = 757941072449241128L;
         private long templeChannelID = 953374742457499659L;
         private long machineChannelID = 1124278424698105940L;

--- a/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
+++ b/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
@@ -203,8 +203,8 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         private IndexationMode startupIndexationMode = IndexationMode.DISABLED;
         private long votingCheckDelay = 60_000L;
         private long votingTime = 60_000L;
-        private long minMessageLength = 0;
-        private long requiredMessagesForBeliever = 300;
+        private long minMessageLength = 300;
+        private long requiredMessagesForBeliever = 100;
         private long domainID = 757941072449241128L;
         private long templeChannelID = 953374742457499659L;
         private long machineChannelID = 1124278424698105940L;

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -65,7 +65,7 @@ public class ExhaustiveMessageIndexer {
 
             if (iteration < 1) {
                 // Only get archived threads in first iteration, since if they remain archived -
-                // that likesly means that no new messages were added to them
+                // that likely means that no new messages were added to them
                 for (TextChannel channel : textChannels) {
                     threads.addAll(this.extractAll(channel.retrieveArchivedPublicThreadChannels()));
                     threads.addAll(this.extractAll(channel.retrieveArchivedPrivateThreadChannels()));
@@ -156,7 +156,7 @@ public class ExhaustiveMessageIndexer {
                         }
 
                         if (!author.isSystem() && !author.isBot()) {
-                            if (author.getIdLong() != Utils.DELETED_USER_ID) {
+                            if (author.getIdLong() != Utils.DELETED_USER_ID) { //TODO Add check for message length if below threshold continue
                                 this.database.addMessageCount(author.getIdLong(), 1);
                             }
                         }

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -28,9 +28,11 @@ public class ExhaustiveMessageIndexer {
     private final AtomicBoolean halt, active;
     private final MachineDatabase database;
     private final Guild guild;
+    private final int minMessageLength;
     private Thread thread;
 
-    public ExhaustiveMessageIndexer(Guild guild, MachineDatabase database) {
+    public ExhaustiveMessageIndexer(Guild guild, MachineDatabase database, int minMessageLength) {
+        this.minMessageLength = minMessageLength;
         this.convergenceHandlers = new ArrayList<>();
         this.guild = guild;
         this.database = database;
@@ -156,8 +158,10 @@ public class ExhaustiveMessageIndexer {
                         }
 
                         if (!author.isSystem() && !author.isBot()) {
-                            if (author.getIdLong() != Utils.DELETED_USER_ID) { //TODO Add check for message length if below threshold continue
-                                this.database.addMessageCount(author.getIdLong(), 1);
+                            if (author.getIdLong() != Utils.DELETED_USER_ID) {
+                                if(!(message.getContentRaw().length() >= minMessageLength)){
+                                    this.database.addMessageCount(author.getIdLong(), 1);
+                                }
                             }
                         }
 

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -159,7 +159,7 @@ public class ExhaustiveMessageIndexer {
 
                         if (!author.isSystem() && !author.isBot()) {
                             if (author.getIdLong() != Utils.DELETED_USER_ID) {
-                                if(!(message.getContentRaw().length() >= minMessageLength)){
+                                if(message.getContentDisplay().length() >= minMessageLength){
                                     this.database.addMessageCount(author.getIdLong(), 1);
                                 }
                             }

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -62,7 +62,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             if (event.getMessage().getInteraction() != null) {
                 user = event.getMessage().getInteraction().getUser();
             }
-
+            // TODO Add check for minimum message length
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
                     this.onNewMessage(user, event.getMessage());
@@ -73,7 +73,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
 
     private void onNewMessage(User user, Message message) {
         int count = this.database.addMessageCount(user.getIdLong(), 1);
-
+        // TODO Change required messages
         if (count >= 300) {
             this.guild.retrieveMember(user).queue(member -> {
                 for (Role role : member.getRoles()) {

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -65,7 +65,9 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             // TODO Add check for minimum message length
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
-                    this.onNewMessage(user, event.getMessage());
+                    if(event.getMessage().getContentRaw().length() >= config.getMinMessageLength()){
+                        this.onNewMessage(user, event.getMessage());
+                    }
                 }
             }
         }
@@ -73,8 +75,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
 
     private void onNewMessage(User user, Message message) {
         int count = this.database.addMessageCount(user.getIdLong(), 1);
-        // TODO Change required messages
-        if (count >= 300) {
+        if (count >= config.getRequiredMessagesForBeliever()) {
             this.guild.retrieveMember(user).queue(member -> {
                 for (Role role : member.getRoles()) {
                     if (this.unvotableRoles.contains(role))

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -62,10 +62,9 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             if (event.getMessage().getInteraction() != null) {
                 user = event.getMessage().getInteraction().getUser();
             }
-            // TODO Add check for minimum message length
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
-                    if(event.getMessage().getContentRaw().length() >= config.getMinMessageLength()){
+                    if(event.getMessage().getContentDisplay().length() >= config.getMinMessageLength()){
                         this.onNewMessage(user, event.getMessage());
                     }
                 }


### PR DESCRIPTION
Added configuration settings for both minimum message length that is required for a message to be counted (default is 0) and a maximum amount of messages that need to be counted for the automatic believer voting process to start (default 300).

Next iteration will see a new evaluation function, new database entries, another config option and perhaps more (depending on whether its necessary or not)

I may or may not have taken the liberty to temper with the arkady thing. Its fully at your discretion whether to keep or remove my tempering.