### PR TITLE
Feature voting rework

### DIFF
--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -44,7 +44,7 @@ public class InfiniteMachine extends ListenerAdapter {
     }
 
     private final JDA jda;
-	private final int minMessageLength;
+    private final int minMessageLength;
     private final Guild domain;
     private final Role believersRole;
     private final Role beholdersRole;

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -44,7 +44,7 @@ public class InfiniteMachine extends ListenerAdapter {
     }
 
     private final JDA jda;
-	private final int minMessageLength;
+    private final int minMessageLength;
     private final Guild domain;
     private final Role believersRole;
     private final Role beholdersRole;
@@ -282,7 +282,7 @@ public class InfiniteMachine extends ListenerAdapter {
 
 	    if (id == 440381346339094539L) {
 			//Added custom bypass of arkadys anti petting code (feel free to remove if you don't agree)
-			if(267067816627273730L == event.getMember().getUser().getIdLong()){
+			if(event.getUser().getIdLong() == 267067816627273730L){
 				msg = String.format("<@%s> has been pet.\nWait how did you do that?", id);
 			}else{
 				msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -23,7 +23,6 @@ import lombok.SneakyThrows;
 import lombok.val;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
@@ -45,6 +44,7 @@ public class InfiniteMachine extends ListenerAdapter {
     }
 
     private final JDA jda;
+	private final int minMessageLength;
     private final Guild domain;
     private final Role believersRole;
     private final Role beholdersRole;
@@ -65,7 +65,7 @@ public class InfiniteMachine extends ListenerAdapter {
     @SneakyThrows
     private InfiniteMachine(JDA jda) {
 	this.jda = jda;
-	this.config = InfiniteConfig.INSTANCE;
+		this.config = InfiniteConfig.INSTANCE;
 	this.database = JSONDatabase.INSTANCE;
 	this.startupTime = System.currentTimeMillis();
 
@@ -103,6 +103,7 @@ public class InfiniteMachine extends ListenerAdapter {
 
 	this.jda.awaitReady();
 
+	this.minMessageLength = (int) this.config.getMinMessageLength();
 	this.domain = jda.getGuildById(this.config.getDomainID());
 
 	if (this.domain == null) {
@@ -319,7 +320,7 @@ public class InfiniteMachine extends ListenerAdapter {
 
 	    if (mode == IndexationMode.EXHAUSTIVE) {
 		if (this.exhaustiveIndexer == null || !this.exhaustiveIndexer.isActive()) {
-		    this.exhaustiveIndexer = new ExhaustiveMessageIndexer(this.domain, this.getDatabase());
+		    this.exhaustiveIndexer = new ExhaustiveMessageIndexer(this.domain, this.getDatabase(), this.minMessageLength);
 		    this.exhaustiveIndexer.onConvergence(() -> {
 			this.machineChannel.sendMessage("Achieved convergence in exhaustive indexation mode, "
 				+ "switching to real-time...").queue();

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -40,7 +40,7 @@ public class InfiniteMachine extends ListenerAdapter {
     public static final InfiniteMachine INSTANCE = new InfiniteMachine(Main.JDA);
 
     static {
-	INSTANCE.awake();
+    INSTANCE.awake();
     }
 
     private final JDA jda;
@@ -64,314 +64,314 @@ public class InfiniteMachine extends ListenerAdapter {
 
     @SneakyThrows
     private InfiniteMachine(JDA jda) {
-	this.jda = jda;
-	this.config = InfiniteConfig.INSTANCE;
-	this.database = JSONDatabase.INSTANCE;
-	this.startupTime = System.currentTimeMillis();
+    this.jda = jda;
+    this.config = InfiniteConfig.INSTANCE;
+    this.database = JSONDatabase.INSTANCE;
+    this.startupTime = System.currentTimeMillis();
 
-	Runtime.getRuntime().addShutdownHook(new Thread(this::trySave));
+    Runtime.getRuntime().addShutdownHook(new Thread(this::trySave));
 
-	// TODO Better localization
-	this.jda.updateCommands().addCommands(
-		Commands.slash("ping", Localization.translate("cmd.ping.desc")),
-		Commands.slash("version", Localization.translate("cmd.version.desc")),
-		Commands.slash("uptime", Localization.translate("cmd.uptime.desc")),
-		Commands.slash("pet", Localization.translate("cmd.pet.desc"))
-		.addOption(OptionType.USER, "user", Localization.translate("cmd.pet.user"), false),
-		Commands.slash("setindexmode", Localization.translate("cmd.setindexmode.desc"))
-		.setDefaultPermissions(DefaultMemberPermissions.DISABLED)
-		.addOption(OptionType.STRING, "mode", Localization.translate("cmd.setindexmode.mode",
-			Arrays.stream(IndexationMode.values()).map(IndexationMode::toString)
-			.collect(Collectors.joining("/"))), true),
-		Commands.slash("getindexmode", Localization.translate("cmd.getindexmode.desc"))
-		.setDefaultPermissions(DefaultMemberPermissions.DISABLED),
-		Commands.slash("terminate", Localization.translate("cmd.terminate.desc"))
-		.setDefaultPermissions(DefaultMemberPermissions.DISABLED),
-		Commands.slash("leaderboard", Localization.translate("cmd.leaderboard.desc"))
-		.addOption(OptionType.INTEGER, "start", Localization.translate("cmd.leaderboard.start"), false),
-		Commands.slash("rating", Localization.translate("cmd.rating.desc"))
-		.addOption(OptionType.USER, "user", Localization.translate("cmd.rating.user"), false),
-		Commands.slash("clearindex", Localization.translate("cmd.clearindex.desc"))
-		.setDefaultPermissions(DefaultMemberPermissions.DISABLED),
-		Commands.slash("openvoting", Localization.translate("cmd.openvoting.desc"))
-		.addOption(OptionType.USER, "user", Localization.translate("cmd.openvoting.user"), true)
-		.addOption(OptionType.STRING, "type",Localization.translate("cmd.openvoting.type",
-			Arrays.stream(Voting.Type.values()).map(Voting.Type::toString)
-			.collect(Collectors.joining("/"))), false)
-		.setDefaultPermissions(DefaultMemberPermissions.DISABLED)
-		).queue();
+    // TODO Better localization
+    this.jda.updateCommands().addCommands(
+        Commands.slash("ping", Localization.translate("cmd.ping.desc")),
+        Commands.slash("version", Localization.translate("cmd.version.desc")),
+        Commands.slash("uptime", Localization.translate("cmd.uptime.desc")),
+        Commands.slash("pet", Localization.translate("cmd.pet.desc"))
+        .addOption(OptionType.USER, "user", Localization.translate("cmd.pet.user"), false),
+        Commands.slash("setindexmode", Localization.translate("cmd.setindexmode.desc"))
+        .setDefaultPermissions(DefaultMemberPermissions.DISABLED)
+        .addOption(OptionType.STRING, "mode", Localization.translate("cmd.setindexmode.mode",
+            Arrays.stream(IndexationMode.values()).map(IndexationMode::toString)
+            .collect(Collectors.joining("/"))), true),
+        Commands.slash("getindexmode", Localization.translate("cmd.getindexmode.desc"))
+        .setDefaultPermissions(DefaultMemberPermissions.DISABLED),
+        Commands.slash("terminate", Localization.translate("cmd.terminate.desc"))
+        .setDefaultPermissions(DefaultMemberPermissions.DISABLED),
+        Commands.slash("leaderboard", Localization.translate("cmd.leaderboard.desc"))
+        .addOption(OptionType.INTEGER, "start", Localization.translate("cmd.leaderboard.start"), false),
+        Commands.slash("rating", Localization.translate("cmd.rating.desc"))
+        .addOption(OptionType.USER, "user", Localization.translate("cmd.rating.user"), false),
+        Commands.slash("clearindex", Localization.translate("cmd.clearindex.desc"))
+        .setDefaultPermissions(DefaultMemberPermissions.DISABLED),
+        Commands.slash("openvoting", Localization.translate("cmd.openvoting.desc"))
+        .addOption(OptionType.USER, "user", Localization.translate("cmd.openvoting.user"), true)
+        .addOption(OptionType.STRING, "type",Localization.translate("cmd.openvoting.type",
+            Arrays.stream(Voting.Type.values()).map(Voting.Type::toString)
+            .collect(Collectors.joining("/"))), false)
+        .setDefaultPermissions(DefaultMemberPermissions.DISABLED)
+        ).queue();
 
-	this.jda.awaitReady();
+    this.jda.awaitReady();
 
-	this.minMessageLength = (int) this.config.getMinMessageLength();
-	this.domain = jda.getGuildById(this.config.getDomainID());
+    this.minMessageLength = (int) this.config.getMinMessageLength();
+    this.domain = jda.getGuildById(this.config.getDomainID());
 
-	if (this.domain == null) {
-	    this.terminate(new RuntimeException("The Architect's Domain not found"));
-	    throw new IllegalStateException();
-	}
+    if (this.domain == null) {
+        this.terminate(new RuntimeException("The Architect's Domain not found"));
+        throw new IllegalStateException();
+    }
 
-	this.templeChannel = this.domain.getTextChannelById(this.config.getTempleChannelID());
-	this.machineChannel = this.domain.getTextChannelById(this.config.getMachineChannelID());
-	this.councilChannel = this.domain.getTextChannelById(this.config.getCouncilChannelID());
-	this.suggestionsChannel = this.domain.getTextChannelById(this.config.getSuggestionsChannelID());
-	this.believersRole = this.domain.getRoleById(this.config.getBelieversRoleID());
-	this.dwellersRole = this.domain.getRoleById(this.config.getDwellersRoleID());
-	this.beholdersRole = this.domain.getRoleById(this.config.getBeholdersRoleID());
+    this.templeChannel = this.domain.getTextChannelById(this.config.getTempleChannelID());
+    this.machineChannel = this.domain.getTextChannelById(this.config.getMachineChannelID());
+    this.councilChannel = this.domain.getTextChannelById(this.config.getCouncilChannelID());
+    this.suggestionsChannel = this.domain.getTextChannelById(this.config.getSuggestionsChannelID());
+    this.believersRole = this.domain.getRoleById(this.config.getBelieversRoleID());
+    this.dwellersRole = this.domain.getRoleById(this.config.getDwellersRoleID());
+    this.beholdersRole = this.domain.getRoleById(this.config.getBeholdersRoleID());
     }
 
     private void awake() {
-	this.votingHandler = new VotingHandler(this.domain, this.councilChannel, this.templeChannel,
-		this.believersRole, this.dwellersRole, ImmutableList.of(this.dwellersRole, this.beholdersRole),
-		this.database);
+    this.votingHandler = new VotingHandler(this.domain, this.councilChannel, this.templeChannel,
+        this.believersRole, this.dwellersRole, ImmutableList.of(this.dwellersRole, this.beholdersRole),
+        this.database);
 
-	this.jda.addEventListener(this);
-	this.jda.addEventListener(this.votingHandler);
+    this.jda.addEventListener(this);
+    this.jda.addEventListener(this.votingHandler);
 
-	this.setIndexationMode(this.config.getStartupIndexationMode());
+    this.setIndexationMode(this.config.getStartupIndexationMode());
 
-	LOGGER.log("Domain channels: " + this.domain.getChannels().size());
+    LOGGER.log("Domain channels: " + this.domain.getChannels().size());
 
-	this.domain.findMembersWithRoles(this.believersRole).onSuccess(list -> {
-	    list.forEach(member -> {
-		int votingCount = this.database.getVotingCount(member.getIdLong());
+    this.domain.findMembersWithRoles(this.believersRole).onSuccess(list -> {
+        list.forEach(member -> {
+        int votingCount = this.database.getVotingCount(member.getIdLong());
 
-		if (votingCount <= 0) {
-		    LOGGER.log("Set starting voting count of user %s to 1.", member.getEffectiveName());
-		    this.database.addVotingCount(member.getIdLong(), 1);
-		}
-	    });
-	});
+        if (votingCount <= 0) {
+            LOGGER.log("Set starting voting count of user %s to 1.", member.getEffectiveName());
+            this.database.addVotingCount(member.getIdLong(), 1);
+        }
+        });
+    });
 
-	String version = this.getVersion();
+    String version = this.getVersion();
 
-	if (!Objects.equals(this.database.getLastVersion(), version)) {
-	    this.database.setLastVersion(version);
-	    this.machineChannel.sendMessage(String.format("<:the_cube:963161249028378735> Version **%s** of"
-		    + " Infinite Machine was deployed successfully.", version)).queue();
-	}
+    if (!Objects.equals(this.database.getLastVersion(), version)) {
+        this.database.setLastVersion(version);
+        this.machineChannel.sendMessage(String.format("<:the_cube:963161249028378735> Version **%s** of"
+            + " Infinite Machine was deployed successfully.", version)).queue();
+    }
     }
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
-	if (event.isFromGuild() && event.getGuild() == this.domain) {
-	    if (event.getChannel() == this.suggestionsChannel) {
-		if (event.getAuthor().isBot() || event.getAuthor().isSystem())
-		    return;
+    if (event.isFromGuild() && event.getGuild() == this.domain) {
+        if (event.getChannel() == this.suggestionsChannel) {
+        if (event.getAuthor().isBot() || event.getAuthor().isSystem())
+            return;
 
-		event.getMessage().addReaction(this.votingHandler.upvote).queue(v -> {
-		    event.getMessage().addReaction(this.votingHandler.downvote).queue();
-		});
-	    }
-	}
+        event.getMessage().addReaction(this.votingHandler.upvote).queue(v -> {
+            event.getMessage().addReaction(this.votingHandler.downvote).queue();
+        });
+        }
+    }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-	if (event.getChannel().getIdLong() != this.machineChannel.getIdLong() &&
-		event.getChannel().getIdLong() != this.templeChannel.getIdLong() &&
-		!"pet".equals(event.getName())) {
-	    event.reply("It is the wrong place and time...").queue();
-	    return;
-	}
+    if (event.getChannel().getIdLong() != this.machineChannel.getIdLong() &&
+        event.getChannel().getIdLong() != this.templeChannel.getIdLong() &&
+        !"pet".equals(event.getName())) {
+        event.reply("It is the wrong place and time...").queue();
+        return;
+    }
 
-	if ("ping".equals(event.getName())) {
-	    long time = System.currentTimeMillis();
-	    event.reply("Pong!").setEphemeral(false).flatMap(v -> event.getHook().editOriginalFormat(
-		    "Pong: %d ms", System.currentTimeMillis() - time)).queue();
-	} else if ("uptime".equals(event.getName())) {
-	    long uptime = System.currentTimeMillis() - this.startupTime;
+    if ("ping".equals(event.getName())) {
+        long time = System.currentTimeMillis();
+        event.reply("Pong!").setEphemeral(false).flatMap(v -> event.getHook().editOriginalFormat(
+            "Pong: %d ms", System.currentTimeMillis() - time)).queue();
+    } else if ("uptime".equals(event.getName())) {
+        long uptime = System.currentTimeMillis() - this.startupTime;
 
-	    long hrs = TimeUnit.MILLISECONDS.toHours(uptime);
-	    uptime -= hrs * 60L * 60L * 1000L;
-	    long mins = TimeUnit.MILLISECONDS.toMinutes(uptime);
-	    uptime -= mins * 60L * 1000L;
-	    long secs = TimeUnit.MILLISECONDS.toSeconds(uptime);
+        long hrs = TimeUnit.MILLISECONDS.toHours(uptime);
+        uptime -= hrs * 60L * 60L * 1000L;
+        long mins = TimeUnit.MILLISECONDS.toMinutes(uptime);
+        uptime -= mins * 60L * 1000L;
+        long secs = TimeUnit.MILLISECONDS.toSeconds(uptime);
 
-	    event.reply(Localization.translate("msg.uptime", hrs, mins, secs)).queue();
-	} else if ("setindexmode".equals(event.getName())) {
-	    event.deferReply().queue();
+        event.reply(Localization.translate("msg.uptime", hrs, mins, secs)).queue();
+    } else if ("setindexmode".equals(event.getName())) {
+        event.deferReply().queue();
 
-	    String modeName = event.getOption("mode").getAsString();
-	    val mode = Arrays.stream(IndexationMode.values()).filter(m -> m.toString().equals(modeName)).findAny();
+        String modeName = event.getOption("mode").getAsString();
+        val mode = Arrays.stream(IndexationMode.values()).filter(m -> m.toString().equals(modeName)).findAny();
 
-	    if (mode.isPresent()) {
-		this.setIndexationMode(mode.get());
-		event.getHook().sendMessage(Localization.translate("msg.indexSetSuccess", mode.get())).queue();
-	    } else {
-		event.getHook().sendMessage(Localization.translate("msg.indexSetError", modeName)).queue();
-	    }
-	} else if ("getindexmode".equals(event.getName())) {
-	    event.reply(Localization.translate("msg.indexGet", this.getIndexationMode().toString())).queue();
-	} else if ("terminate".equals(event.getName())) {
-	    event.reply(Localization.translate("msg.termination")).submit().whenCompleteAsync(
-		    (a, b) -> this.shutdown());
-	} else if ("leaderboard".equals(event.getName())) {
-	    event.deferReply().flatMap(v -> {
-		val option = event.getOption("start");
-		int start = option != null ? Math.max(option.getAsInt(), 1) : 1;
+        if (mode.isPresent()) {
+        this.setIndexationMode(mode.get());
+        event.getHook().sendMessage(Localization.translate("msg.indexSetSuccess", mode.get())).queue();
+        } else {
+        event.getHook().sendMessage(Localization.translate("msg.indexSetError", modeName)).queue();
+        }
+    } else if ("getindexmode".equals(event.getName())) {
+        event.reply(Localization.translate("msg.indexGet", this.getIndexationMode().toString())).queue();
+    } else if ("terminate".equals(event.getName())) {
+        event.reply(Localization.translate("msg.termination")).submit().whenCompleteAsync(
+            (a, b) -> this.shutdown());
+    } else if ("leaderboard".equals(event.getName())) {
+        event.deferReply().flatMap(v -> {
+        val option = event.getOption("start");
+        int start = option != null ? Math.max(option.getAsInt(), 1) : 1;
 
-		val senders = this.getDatabase().getTopMessageSenders(this.jda, this.domain, start, 10);
-		String reply = "";
+        val senders = this.getDatabase().getTopMessageSenders(this.jda, this.domain, start, 10);
+        String reply = "";
 
-		if (start == 1) {
-		    reply += Localization.translate("msg.leaderboardHeader") + "\n";
-		} else {
-		    reply += Localization.translate("msg.leaderboardHeaderAlt", start, start + 9) + "\n";
-		}
+        if (start == 1) {
+            reply += Localization.translate("msg.leaderboardHeader") + "\n";
+        } else {
+            reply += Localization.translate("msg.leaderboardHeaderAlt", start, start + 9) + "\n";
+        }
 
-		for (int i = 0; i < senders.size(); i++) {
-		    val triple = senders.get(i);
-		    reply += "\n" + Localization.translate("msg.leaderboardEntry", i + start, triple.getB(),
-			    triple.getA(), triple.getC());
-		}
+        for (int i = 0; i < senders.size(); i++) {
+            val triple = senders.get(i);
+            reply += "\n" + Localization.translate("msg.leaderboardEntry", i + start, triple.getB(),
+                triple.getA(), triple.getC());
+        }
 
-		return event.getHook().sendMessage(reply).setAllowedMentions(Collections.EMPTY_LIST);
-	    }).queue();
-	} else if ("rating".equals(event.getName())) {
-	    event.deferReply().flatMap(v -> {
-		OptionMapping mapping = event.getOption("user");
-		User user = null;
-		String message = null;
+        return event.getHook().sendMessage(reply).setAllowedMentions(Collections.EMPTY_LIST);
+        }).queue();
+    } else if ("rating".equals(event.getName())) {
+        event.deferReply().flatMap(v -> {
+        OptionMapping mapping = event.getOption("user");
+        User user = null;
+        String message = null;
 
-		if (mapping != null && mapping.getAsUser() != event.getUser()) {
-		    user = mapping.getAsUser();
-		    val rating = this.database.getSenderRating(this.jda, this.domain, user.getIdLong());
-		    message = Localization.translate("msg.rating", user.getIdLong(), rating.getA(),
-			    rating.getB());
-		} else {
-		    user = event.getUser();
-		    val rating = this.database.getSenderRating(this.jda, this.domain, user.getIdLong());
-		    message = Localization.translate("msg.ratingOwn", rating.getA(), rating.getB());
-		}
+        if (mapping != null && mapping.getAsUser() != event.getUser()) {
+            user = mapping.getAsUser();
+            val rating = this.database.getSenderRating(this.jda, this.domain, user.getIdLong());
+            message = Localization.translate("msg.rating", user.getIdLong(), rating.getA(),
+                rating.getB());
+        } else {
+            user = event.getUser();
+            val rating = this.database.getSenderRating(this.jda, this.domain, user.getIdLong());
+            message = Localization.translate("msg.ratingOwn", rating.getA(), rating.getB());
+        }
 
-		return event.getHook().sendMessage(message).setAllowedMentions(Collections.EMPTY_LIST);
-	    }).queue();
-	} else if ("clearindex".equals(event.getName())) {
-	    event.deferReply().flatMap(v -> {
-		this.getDatabase().resetIndexation();
-		this.getDatabase().forceSave();
-		return event.getHook().sendMessage(Localization.translate("msg.indexReset"));
-	    }).queue();
-	} else if ("openvoting".equals(event.getName())) {
-	    event.deferReply().setEphemeral(true).queue();
+        return event.getHook().sendMessage(message).setAllowedMentions(Collections.EMPTY_LIST);
+        }).queue();
+    } else if ("clearindex".equals(event.getName())) {
+        event.deferReply().flatMap(v -> {
+        this.getDatabase().resetIndexation();
+        this.getDatabase().forceSave();
+        return event.getHook().sendMessage(Localization.translate("msg.indexReset"));
+        }).queue();
+    } else if ("openvoting".equals(event.getName())) {
+        event.deferReply().setEphemeral(true).queue();
 
-	    User user = event.getOption("user").getAsUser();
-	    OptionMapping typeMapping = event.getOption("type");
-	    Voting.Type type = typeMapping != null ? Voting.Type.valueOf(typeMapping.getAsString())
-		    : Voting.Type.GRANT_ROLE;
+        User user = event.getOption("user").getAsUser();
+        OptionMapping typeMapping = event.getOption("type");
+        Voting.Type type = typeMapping != null ? Voting.Type.valueOf(typeMapping.getAsString())
+            : Voting.Type.GRANT_ROLE;
 
-	    this.getDatabase().addMessageCount(user.getIdLong(), 1);
-	    this.votingHandler.openVoting(user, -1, false, type).thenAccept(voting -> {
-		if (voting == null) {
-		    event.getHook().sendMessage(Localization.translate("msg.openVotingFail", user.getId()))
-		    .queue();
-		} else {
-		    event.getHook().sendMessage(Localization.translate("msg.openVotingSuccess", user.getId()))
-		    .queue();
-		}
-	    });
-	} else if ("version".equals(event.getName())) {
-	    event.reply(String.format("The machine's version is: **%s**", this.getVersion())).queue();
-	} else if ("pet".equals(event.getName())) {
-	    OptionMapping mapping = event.getOption("user");
-	    long id = mapping != null ? mapping.getAsUser().getIdLong() : 310848622642069504L;
+        this.getDatabase().addMessageCount(user.getIdLong(), 1);
+        this.votingHandler.openVoting(user, -1, false, type).thenAccept(voting -> {
+        if (voting == null) {
+            event.getHook().sendMessage(Localization.translate("msg.openVotingFail", user.getId()))
+            .queue();
+        } else {
+            event.getHook().sendMessage(Localization.translate("msg.openVotingSuccess", user.getId()))
+            .queue();
+        }
+        });
+    } else if ("version".equals(event.getName())) {
+        event.reply(String.format("The machine's version is: **%s**", this.getVersion())).queue();
+    } else if ("pet".equals(event.getName())) {
+        OptionMapping mapping = event.getOption("user");
+        long id = mapping != null ? mapping.getAsUser().getIdLong() : 310848622642069504L;
 
-	    String msg = "<@%s> has been pet.";
+        String msg = "<@%s> has been pet.";
 
-	    if (id == 440381346339094539L) {
-			//Added custom bypass of arkadys anti petting code (feel free to remove if you don't agree)
-			if(267067816627273730L == event.getMember().getUser().getIdLong()){
-				msg = String.format("<@%s> has been pet.\nWait how did you do that?", id);
-			}else{
-				msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"
-						+ "No matter what machines you wield...";
-			}
+        if (id == 440381346339094539L) {
+            //Added custom bypass of arkadys anti petting code (feel free to remove if you don't agree)
+            if(event.getUser().getIdLong() == 267067816627273730L){
+                msg = String.format("<@%s> has been pet.\nWait how did you do that?", id);
+            }else{
+                msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"
+                        + "No matter what machines you wield...";
+            }
 
-		event.reply(msg).queue();
-		return;
-	    } else if (id == 1124053065109098708L) { // bot's own ID
-		msg = "At the end of times, the <@%s> has pet itself.";
-	    }
+        event.reply(msg).queue();
+        return;
+        } else if (id == 1124053065109098708L) { // bot's own ID
+        msg = "At the end of times, the <@%s> has pet itself.";
+        }
 
-	    event.reply(String.format(msg, id)).queue();
-	}
+        event.reply(String.format(msg, id)).queue();
+    }
     }
 
     public JDA getJDA() {
-	return this.jda;
+    return this.jda;
     }
 
     public String getVersion() {
-	String version = Main.class.getPackage().getImplementationVersion();
-	return version != null ? version : "UNKNOWN";
+    String version = Main.class.getPackage().getImplementationVersion();
+    return version != null ? version : "UNKNOWN";
     }
 
     public void setIndexationMode(IndexationMode mode) {
-	if (this.indexationMode != mode) {
-	    this.indexationMode = mode;
+    if (this.indexationMode != mode) {
+        this.indexationMode = mode;
 
-	    if (mode != IndexationMode.EXHAUSTIVE) {
-		if (this.exhaustiveIndexer != null && this.exhaustiveIndexer.isActive()) {
-		    this.exhaustiveIndexer.halt();
-		}
-	    }
+        if (mode != IndexationMode.EXHAUSTIVE) {
+        if (this.exhaustiveIndexer != null && this.exhaustiveIndexer.isActive()) {
+            this.exhaustiveIndexer.halt();
+        }
+        }
 
-	    if (mode != IndexationMode.REALTIME) {
-		if (this.realtimeIndexer != null && this.realtimeIndexer.isEnabled()) {
-		    this.realtimeIndexer.disable();
-		}
-	    }
+        if (mode != IndexationMode.REALTIME) {
+        if (this.realtimeIndexer != null && this.realtimeIndexer.isEnabled()) {
+            this.realtimeIndexer.disable();
+        }
+        }
 
-	    if (mode == IndexationMode.EXHAUSTIVE) {
-		if (this.exhaustiveIndexer == null || !this.exhaustiveIndexer.isActive()) {
-		    this.exhaustiveIndexer = new ExhaustiveMessageIndexer(this.domain, this.getDatabase(), this.minMessageLength);
-		    this.exhaustiveIndexer.onConvergence(() -> {
-			this.machineChannel.sendMessage("Achieved convergence in exhaustive indexation mode, "
-				+ "switching to real-time...").queue();
-			this.setIndexationMode(IndexationMode.REALTIME);
-		    });
-		    this.exhaustiveIndexer.activate();
-		}
-	    } else if (mode == IndexationMode.REALTIME) {
-		if (this.realtimeIndexer == null) {
-		    this.realtimeIndexer = new RealtimeMessageIndexer(this.domain, this.getDatabase());
-		    this.jda.addEventListener(this.realtimeIndexer);
-		}
+        if (mode == IndexationMode.EXHAUSTIVE) {
+        if (this.exhaustiveIndexer == null || !this.exhaustiveIndexer.isActive()) {
+            this.exhaustiveIndexer = new ExhaustiveMessageIndexer(this.domain, this.getDatabase(), this.minMessageLength);
+            this.exhaustiveIndexer.onConvergence(() -> {
+            this.machineChannel.sendMessage("Achieved convergence in exhaustive indexation mode, "
+                + "switching to real-time...").queue();
+            this.setIndexationMode(IndexationMode.REALTIME);
+            });
+            this.exhaustiveIndexer.activate();
+        }
+        } else if (mode == IndexationMode.REALTIME) {
+        if (this.realtimeIndexer == null) {
+            this.realtimeIndexer = new RealtimeMessageIndexer(this.domain, this.getDatabase());
+            this.jda.addEventListener(this.realtimeIndexer);
+        }
 
-		if (!this.realtimeIndexer.isEnabled()) {
-		    this.realtimeIndexer.enable();
-		}
-	    }
-	}
+        if (!this.realtimeIndexer.isEnabled()) {
+            this.realtimeIndexer.enable();
+        }
+        }
+    }
     }
 
     public void terminate(Throwable reason) {
-	LOGGER.error("Infinite Machine has encountered a fatal error:", reason);
-	LOGGER.error("Initiating termination sequence...");
-	this.trySave();
+    LOGGER.error("Infinite Machine has encountered a fatal error:", reason);
+    LOGGER.error("Initiating termination sequence...");
+    this.trySave();
 
-	LOGGER.log("Database saved, calling system exit.");
-	System.exit(1);
+    LOGGER.log("Database saved, calling system exit.");
+    System.exit(1);
     }
 
     public void shutdown() {
-	LOGGER.log("Infinite Machine is shutting down...");
-	this.trySave();
+    LOGGER.log("Infinite Machine is shutting down...");
+    this.trySave();
 
-	LOGGER.log("Database saved, calling system exit.");
-	System.exit(0);
+    LOGGER.log("Database saved, calling system exit.");
+    System.exit(0);
     }
 
     private void trySave() {
-	LOGGER.log("Trying to save the database...");
+    LOGGER.log("Trying to save the database...");
 
-	try {
-	    this.database.forceSave();
-	} catch (Throwable ex) {
-	    LOGGER.error("Failed to save database! Stacktrace:", ex);
-	}
+    try {
+        this.database.forceSave();
+    } catch (Throwable ex) {
+        LOGGER.error("Failed to save database! Stacktrace:", ex);
+    }
     }
 
 }

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -281,8 +281,14 @@ public class InfiniteMachine extends ListenerAdapter {
 	    String msg = "<@%s> has been pet.";
 
 	    if (id == 440381346339094539L) {
-		msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"
-			+ "No matter what machines you wield...";
+			//Added custom bypass of arkadys anti petting code (feel free to remove if you don't agree)
+			if(267067816627273730L == event.getMember().getUser().getIdLong()){
+				msg = String.format("<@%s> has been pet.\nWait how did you do that?", id);
+			}else{
+				msg = "You should know, that a soul can't be `/pet`\n(CAN'T BE `/PET`!)\n"
+						+ "No matter what machines you wield...";
+			}
+
 		event.reply(msg).queue();
 		return;
 	    } else if (id == 1124053065109098708L) { // bot's own ID

--- a/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
+++ b/src/main/java/com/aizistral/infmachine/InfiniteMachine.java
@@ -65,7 +65,7 @@ public class InfiniteMachine extends ListenerAdapter {
     @SneakyThrows
     private InfiniteMachine(JDA jda) {
 	this.jda = jda;
-		this.config = InfiniteConfig.INSTANCE;
+	this.config = InfiniteConfig.INSTANCE;
 	this.database = JSONDatabase.INSTANCE;
 	this.startupTime = System.currentTimeMillis();
 

--- a/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
+++ b/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
@@ -53,6 +53,24 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         }
     }
 
+    public long getMinMessageLength() {
+        try {
+            this.readLock.lock();
+            return this.getData().minMessageLength;
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
+    public long getRequiredMessagesForBeliever() {
+        try {
+            this.readLock.lock();
+            return this.getData().requiredMessagesForBeliever;
+        } finally {
+            this.readLock.unlock();
+        }
+    }
+
     public long getDomainID() {
         try {
             this.readLock.lock();
@@ -185,6 +203,8 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         private IndexationMode startupIndexationMode = IndexationMode.DISABLED;
         private long votingCheckDelay = 60_000L;
         private long votingTime = 60_000L;
+        private long minMessageLength = 0;
+        private long requiredMessagesForBeliever = 300;
         private long domainID = 757941072449241128L;
         private long templeChannelID = 953374742457499659L;
         private long machineChannelID = 1124278424698105940L;

--- a/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
+++ b/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
@@ -203,8 +203,8 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         private IndexationMode startupIndexationMode = IndexationMode.DISABLED;
         private long votingCheckDelay = 60_000L;
         private long votingTime = 60_000L;
-        private long minMessageLength = 0;
-        private long requiredMessagesForBeliever = 300;
+        private long minMessageLength = 300;
+        private long requiredMessagesForBeliever = 100;
         private long domainID = 757941072449241128L;
         private long templeChannelID = 953374742457499659L;
         private long machineChannelID = 1124278424698105940L;

--- a/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
+++ b/src/main/java/com/aizistral/infmachine/config/InfiniteConfig.java
@@ -203,8 +203,8 @@ public class InfiniteConfig extends AsyncJSONConfig<InfiniteConfig.Data> {
         private IndexationMode startupIndexationMode = IndexationMode.DISABLED;
         private long votingCheckDelay = 60_000L;
         private long votingTime = 60_000L;
-        private long minMessageLength = 300;
-        private long requiredMessagesForBeliever = 100;
+        private long minMessageLength = 0;
+        private long requiredMessagesForBeliever = 300;
         private long domainID = 757941072449241128L;
         private long templeChannelID = 953374742457499659L;
         private long machineChannelID = 1124278424698105940L;

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -65,7 +65,7 @@ public class ExhaustiveMessageIndexer {
 
             if (iteration < 1) {
                 // Only get archived threads in first iteration, since if they remain archived -
-                // that likesly means that no new messages were added to them
+                // that likely means that no new messages were added to them
                 for (TextChannel channel : textChannels) {
                     threads.addAll(this.extractAll(channel.retrieveArchivedPublicThreadChannels()));
                     threads.addAll(this.extractAll(channel.retrieveArchivedPrivateThreadChannels()));
@@ -156,7 +156,7 @@ public class ExhaustiveMessageIndexer {
                         }
 
                         if (!author.isSystem() && !author.isBot()) {
-                            if (author.getIdLong() != Utils.DELETED_USER_ID) {
+                            if (author.getIdLong() != Utils.DELETED_USER_ID) { //TODO Add check for message length if below threshold continue
                                 this.database.addMessageCount(author.getIdLong(), 1);
                             }
                         }

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -28,9 +28,11 @@ public class ExhaustiveMessageIndexer {
     private final AtomicBoolean halt, active;
     private final MachineDatabase database;
     private final Guild guild;
+    private final int minMessageLength;
     private Thread thread;
 
-    public ExhaustiveMessageIndexer(Guild guild, MachineDatabase database) {
+    public ExhaustiveMessageIndexer(Guild guild, MachineDatabase database, int minMessageLength) {
+        this.minMessageLength = minMessageLength;
         this.convergenceHandlers = new ArrayList<>();
         this.guild = guild;
         this.database = database;
@@ -156,8 +158,10 @@ public class ExhaustiveMessageIndexer {
                         }
 
                         if (!author.isSystem() && !author.isBot()) {
-                            if (author.getIdLong() != Utils.DELETED_USER_ID) { //TODO Add check for message length if below threshold continue
-                                this.database.addMessageCount(author.getIdLong(), 1);
+                            if (author.getIdLong() != Utils.DELETED_USER_ID) {
+                                if(!(message.getContentRaw().length() >= minMessageLength)){
+                                    this.database.addMessageCount(author.getIdLong(), 1);
+                                }
                             }
                         }
 

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -159,7 +159,7 @@ public class ExhaustiveMessageIndexer {
 
                         if (!author.isSystem() && !author.isBot()) {
                             if (author.getIdLong() != Utils.DELETED_USER_ID) {
-                                if(message.getContentDisplay().length() >= minMessageLength){
+                                if(message.getContentRaw().length() >= minMessageLength){
                                     this.database.addMessageCount(author.getIdLong(), 1);
                                 }
                             }

--- a/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/ExhaustiveMessageIndexer.java
@@ -159,7 +159,7 @@ public class ExhaustiveMessageIndexer {
 
                         if (!author.isSystem() && !author.isBot()) {
                             if (author.getIdLong() != Utils.DELETED_USER_ID) {
-                                if(!(message.getContentRaw().length() >= minMessageLength)){
+                                if(message.getContentDisplay().length() >= minMessageLength){
                                     this.database.addMessageCount(author.getIdLong(), 1);
                                 }
                             }

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -62,7 +62,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             if (event.getMessage().getInteraction() != null) {
                 user = event.getMessage().getInteraction().getUser();
             }
-
+            // TODO Add check for minimum message length
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
                     this.onNewMessage(user, event.getMessage());
@@ -73,7 +73,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
 
     private void onNewMessage(User user, Message message) {
         int count = this.database.addMessageCount(user.getIdLong(), 1);
-
+        // TODO Change required messages
         if (count >= 300) {
             this.guild.retrieveMember(user).queue(member -> {
                 for (Role role : member.getRoles()) {

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -64,7 +64,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             }
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
-                    if(event.getMessage().getContentDisplay().length() >= config.getMinMessageLength()){
+                    if(event.getMessage().getContentRaw().length() >= config.getMinMessageLength()){
                         this.onNewMessage(user, event.getMessage());
                     }
                 }

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -65,7 +65,9 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             // TODO Add check for minimum message length
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
-                    this.onNewMessage(user, event.getMessage());
+                    if(event.getMessage().getContentRaw().length() >= config.getMinMessageLength()){
+                        this.onNewMessage(user, event.getMessage());
+                    }
                 }
             }
         }
@@ -73,8 +75,7 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
 
     private void onNewMessage(User user, Message message) {
         int count = this.database.addMessageCount(user.getIdLong(), 1);
-        // TODO Change required messages
-        if (count >= 300) {
+        if (count >= config.getRequiredMessagesForBeliever()) {
             this.guild.retrieveMember(user).queue(member -> {
                 for (Role role : member.getRoles()) {
                     if (this.unvotableRoles.contains(role))

--- a/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
+++ b/src/main/java/com/aizistral/infmachine/indexation/RealtimeMessageIndexer.java
@@ -62,10 +62,9 @@ public class RealtimeMessageIndexer extends ListenerAdapter {
             if (event.getMessage().getInteraction() != null) {
                 user = event.getMessage().getInteraction().getUser();
             }
-            // TODO Add check for minimum message length
             if (!user.isBot() && !user.isSystem()) {
                 if (user.getIdLong() != Utils.DELETED_USER_ID) {
-                    if(event.getMessage().getContentRaw().length() >= config.getMinMessageLength()){
+                    if(event.getMessage().getContentDisplay().length() >= config.getMinMessageLength()){
                         this.onNewMessage(user, event.getMessage());
                     }
                 }


### PR DESCRIPTION
Added configuration settings for both minimum message length that is required for a message to be counted (default is 0) and a maximum amount of messages that need to be counted for the automatic believer voting process to start (default 300).

Next iteration will see a new evaluation function, new database entries, another config option and perhaps more (depending on whether its necessary or not)

I may or may not have taken the liberty to temper with the arkady thing. Its fully at your discretion whether to keep or remove my tempering.

This time i have double checked that everything is as it should be.